### PR TITLE
Add selection for current selected date

### DIFF
--- a/index.php
+++ b/index.php
@@ -47,6 +47,9 @@ while ($row = $result->fetch_assoc()) {
                   overflow-y: hidden;
                   padding: 5px;
                 }
+                textarea.selected {
+                  border: 1px dotted;
+                }
                 * {
                   padding: 0;
                   margin: 0;
@@ -183,6 +186,11 @@ echo "          </tr>\n";
           var original_values = {};
           $('textarea').each(function(i, element) {
             original_values[element.id] = element.value;
+          });
+
+          $('textarea').click(function() {
+            $("textarea.selected").removeClass("selected");
+            $(this).addClass('selected');
           });
 
           $('textarea').on('input', function(event) {


### PR DESCRIPTION
Since the date is written in the lower right of the textbox, it's hard to determine which box is selected. A user might end up editing the wrong box. Adding some css will make it more obvious which date is being edited.